### PR TITLE
different recursive and strictness modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,8 @@ endif()
 
 ############# codecov
 if (${ENABLE_COVERAGE})
-    SET(CMAKE_CXX_FLAGS_DEBUG "-O0")
-    SET(CMAKE_C_FLAGS_DEBUG "-O0")
+    SET(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -fno-inline-small-functions -fno-default-inline")
+    SET(CMAKE_C_FLAGS_DEBUG "-O0 -fno-inline -fno-inline-small-functions -fno-default-inline")
     set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/CMake-codecov/cmake" ${CMAKE_MODULE_PATH})
     find_package(codecov)
     add_coverage(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ conan_cmake_install(PATH_OR_REFERENCE . BUILD missing SETTINGS ${settings})
 option(ENABLE_TESTS "Enable tests" OFF)
 option(ENABLE_TSAN "Enable tsan" OFF)
 option(ENABLE_COVERAGE "Enable coverage" OFF)
+option(ENABLE_TRACE "Enable lock tracing" OFF)
 
 if (${ENABLE_TESTS})
 
@@ -61,6 +62,9 @@ if (${ENABLE_TSAN})
   target_link_libraries(tests PRIVATE tsan)
 endif()
 
+if (${ENABLE_TRACE})
+    target_compile_definitions(tests  PRIVATE "-DHILOK_TRACE")
+endif()
 
 ############# codecov
 if (${ENABLE_COVERAGE})

--- a/src/hilok.cpp
+++ b/src/hilok.cpp
@@ -190,7 +190,7 @@ void HiLok::rename(std::string_view path_from, std::string_view path_to, bool bl
             ++it_from;
             if (to_key == from_key) {
 #ifdef HILOK_TRACE
-                std::cout << "ig: " << key.first << "/" << key.second << std::endl;
+                std::cout << "ig: " << to_key.first << "/" << to_key.second << std::endl;
 #endif
                 auto it = m_map.find(to_key);
                 cur_to = it->second;
@@ -213,12 +213,20 @@ void HiLok::rename(std::string_view path_from, std::string_view path_to, bool bl
             }
 
 #ifdef HILOK_TRACE
-            std::cout << "clon lk: " << key.first << "/" << key.second << ":" << cur_to << " " << leaf_from_node->m_mut.m_is_ex << std::endl;
+            std::cout << "clon was: " << cur_to->m_mut.m_num_r << std::endl;
+#endif
+
+#ifdef HILOK_TRACE
+            std::cout << "clon lk: " << to_key.first << "/" << to_key.second << ":" << cur_to << " " << leaf_from_node->m_mut.m_num_r + leaf_from_node->m_mut.m_is_ex << std::endl;
 #endif
             // copy lock counts from the leaf to the ancestor
             if (!cur_to->m_mut.unsafe_clone_lock_shared(leaf_from_node->m_mut, block, secs)) {
                 throw HiErr("unable to lock rename dest");
             }
+
+#ifdef HILOK_TRACE
+            std::cout << "clon new: " << cur_to->m_mut.m_num_r << std::endl;
+#endif
         }
     }
 
@@ -235,7 +243,7 @@ void HiLok::rename(std::string_view path_from, std::string_view path_to, bool bl
         cur_from = it->second;
 
 #ifdef HILOK_TRACE
-        std::cout << "clon un: " << from_key.first << "/" << from_key.second << ":" << cur_from << std::endl;
+        std::cout << "clon un: " << from_key.first << "/" << from_key.second << ":" << cur_from << " " << leaf_from_node->m_mut.m_num_r + leaf_from_node->m_mut.m_is_ex << std::endl;
 #endif
         // unlock uncommon ancestors of the source
         cur_from->m_mut.unsafe_clone_unlock_shared(leaf_from_node->m_mut);

--- a/src/hilok.cpp
+++ b/src/hilok.cpp
@@ -213,41 +213,38 @@ void HiLok::rename(std::string_view path_from, std::string_view path_to, bool bl
             if (!cur_to->m_mut.unsafe_clone_lock_shared(leaf_from_node->m_mut, block, secs)) {
                 throw HiErr("unable to lock rename dest");
             }
-        } else {
-            cur_to.reset(); // refcount for erase
+        }
+    }
+    cur_to.reset(); // refcount for erase
 
-            while (it_from != it_from.end()) {
-                // uncommon ancestor of source must be released
-                ++it_from;
+    while (it_from != it_from.end()) {
+        // uncommon ancestor of source must be released
+        ++it_from;
 
-                auto it = m_map.find(from_key);
+        auto it = m_map.find(from_key);
 
-                // we already tested for this above, and we have a mutex, should never happen
-                assert(it != m_map.end());
+        // we already tested for this above, and we have a mutex, should never happen
+        assert(it != m_map.end());
 
-                cur_from = it->second;
+        cur_from = it->second;
 
 #ifdef HILOK_TRACE
-                std::cout << "clon un: " << from_key.first << "/" << from_key.second << ":" << cur_from << std::endl;
+        std::cout << "clon un: " << from_key.first << "/" << from_key.second << ":" << cur_from << std::endl;
 #endif
-                // unlock uncommon ancestors of the source
-                cur_from->m_mut.unsafe_clone_unlock_shared(leaf_from_node->m_mut);
+        // unlock uncommon ancestors of the source
+        cur_from->m_mut.unsafe_clone_unlock_shared(leaf_from_node->m_mut);
 
-                from_key.first.reset(); // refcount for erase
-                // could have went to 0
-                erase_unsafe(cur_from);
-            
-                from_key = {cur_from, *it_from};
-            }
-
-            // keep leaf locks, change key
-            m_map.erase(leaf_from_node->m_key);
-            leaf_from_node->m_key = key;
-            m_map[key] = leaf_from_node;        
-       } 
+        from_key.first.reset(); // refcount for erase
+        // could have went to 0
+        erase_unsafe(cur_from);
+    
+        from_key = {cur_from, *it_from};
     }
 
-
+    // keep leaf locks, change key
+    m_map.erase(leaf_from_node->m_key);
+    leaf_from_node->m_key = key;
+    m_map[key] = leaf_from_node;        
 }
 
 

--- a/src/hilok.cpp
+++ b/src/hilok.cpp
@@ -49,12 +49,18 @@ void HiHandle::release() {
 #ifdef HILOK_TRACE
             std::cout << "un: " << kref << " " << 0 << " " << m_shared << std::endl;
 #endif
-            kref->m_mut.unlock_shared();
+            if (m_mgr->m_flags & HiFlags::LOOSE_READ_UNLOCK)
+                kref->m_mut.unlock_shared(m_src_thread);
+            else 
+                kref->m_mut.unlock_shared();
         } else {
 #ifdef HILOK_TRACE
             std::cout << "un: " << kref << " " << 1 << " " << m_shared << std::endl;
 #endif
-            kref->m_mut.unlock();
+            if (m_mgr->m_flags & HiFlags::LOOSE_WRITE_UNLOCK)
+                kref->m_mut.unlock(m_src_thread);
+            else 
+                kref->m_mut.unlock();
         }
         m_mgr->erase_safe(kref);
     }

--- a/src/hilok.cpp
+++ b/src/hilok.cpp
@@ -91,7 +91,7 @@ std::shared_ptr<HiKeyNode> HiLok::_get_node(const std::pair<std::shared_ptr<HiKe
     auto it = m_map.find(key);
     std::shared_ptr<HiKeyNode> ret;
     if (it == m_map.end()) {
-        ret = m_map[key] = std::make_shared<HiKeyNode>(key, is_recursive());
+        ret = m_map[key] = std::make_shared<HiKeyNode>(key, m_flags);
     } else {
         ret = it->second;
     }
@@ -201,7 +201,7 @@ void HiLok::rename(std::string_view path_from, std::string_view path_to, bool bl
 
             auto it = m_map.find(key);
             if (it == m_map.end()) {
-                cur_to = m_map[key] = std::make_shared<HiKeyNode>(key, is_recursive());
+                cur_to = m_map[key] = std::make_shared<HiKeyNode>(key, m_flags);
             } else {
                 cur_to = it->second;
             }

--- a/src/hilok.cpp
+++ b/src/hilok.cpp
@@ -260,7 +260,7 @@ void HiLok::rename(std::string_view path_from, std::string_view path_to, bool bl
     cur_to.reset();
     cur_from.reset();
 
-    for (auto nod : to_erase) {
+    for (auto &nod : to_erase) {
         erase_unsafe(nod);
     }
 

--- a/src/hilok.cpp
+++ b/src/hilok.cpp
@@ -246,7 +246,8 @@ void HiLok::rename(std::string_view path_from, std::string_view path_to, bool bl
         
         ++it_from;
     }
-    
+   
+    // lower refs for erase hint
     from_key.first.reset();
     cur_to.reset();
     cur_from.reset();

--- a/src/hilok.hpp
+++ b/src/hilok.hpp
@@ -15,7 +15,7 @@
 #define mut_op_1(op, a) (m_rec_flags ? m_r_mut.op(a) : m_t_mut.op(a))
 
  enum HiFlags { 
-     NONE = 0,                  // no recursion, strict release
+     STRICT = 0,                // no recursion, strict release
      RECURSIVE_WRITE = 1,       // allow recursive write locks
      RECURSIVE_READ = 2,        // allow recursive write/read read/write locks
      RECURSIVE = 3,             // allow both recursive write & read locks

--- a/src/hilok.hpp
+++ b/src/hilok.hpp
@@ -50,7 +50,7 @@ public:
 
 
     bool unsafe_clone_lock_shared(HiMutex &src, bool block, double secs) {
-        auto num = (src.m_num_r + (src.m_is_ex ? 1 : 0));
+        auto num = (m_num_r + src.m_num_r + (src.m_is_ex ? 1 : 0));
         while (m_num_r < num) {
             if (!lock_shared(block, secs)) {
                 return false;

--- a/src/hilok.hpp
+++ b/src/hilok.hpp
@@ -204,7 +204,10 @@ public:
     HiHandle & operator= ( const HiHandle & ) = delete;
 
     virtual ~HiHandle() {
-        release();
+        try {
+            release();
+        } catch (HiErr &) {
+        }
     }
 
     void release();

--- a/src/hilok.hpp
+++ b/src/hilok.hpp
@@ -35,7 +35,7 @@ public:
     bool m_is_ex;
 
     HiMutex(int rec_flags) : m_r_mut(!(rec_flags & HiFlags::RECURSIVE_READ)), m_num_r(0), m_rec_flags(rec_flags), m_is_ex(false) {
-        if (rec_flags == 2) 
+        if ((rec_flags & HiFlags::RECURSIVE) == HiFlags::RECURSIVE_READ) 
             throw std::logic_error("recursive read only is not supported");
     }
     HiMutex(bool) = delete;

--- a/src/hilok.hpp
+++ b/src/hilok.hpp
@@ -34,8 +34,8 @@ public:
     bool m_is_ex;
 
     HiMutex(int rec_flags) : m_r_mut(!(rec_flags & HiFlags::RECURSIVE_READ)), m_num_r(0), m_rec_flags(rec_flags), m_is_ex(false) {
-        if (!(rec_flags == 3 || rec_flags == 0))
-            throw std::runtime_error("wtf");
+        if (rec_flags == 2) 
+            throw std::logic_error("recursive read only is not supported");
     }
     HiMutex(bool) = delete;
 

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -43,13 +43,13 @@ PYBIND11_MODULE(hilok, m)
         .def("__exit__", [](std::shared_ptr<HiHandle> hh, const py::object &, const py::object &, const py::object &) { hh->release(); })
         ;
 
-    py::enum_<HiFlags>(m, "Flags", py::arithmetic())
-        .value("HI_RECURSIVE_READ", HiFlags::RECURSIVE_READ)
-        .value("HI_RECURSIVE_WRITE", HiFlags::RECURSIVE_WRITE)
-        .value("HI_LOOSE_READ_UNLOCK", HiFlags::LOOSE_READ_UNLOCK)
-        .value("HI_LOOSE_WRITE_UNLOCK", HiFlags::LOOSE_WRITE_UNLOCK)
-        .value("HI_RECURSIVE_ALL", static_cast<HiFlags>(HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE))
-        .export_values();
+    py::enum_<HiFlags>(m, "HiLokFlags", py::arithmetic())
+        .value("STRICT", HiFlags::STRICT)
+        .value("LOOSE_READ_UNLOCK", HiFlags::LOOSE_READ_UNLOCK)
+        .value("LOOSE_WRITE_UNLOCK", HiFlags::LOOSE_WRITE_UNLOCK)
+        .value("RECURSIVE_WRITE", HiFlags::RECURSIVE_WRITE)
+        .value("RECURSIVE", static_cast<HiFlags>(HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE))
+        .value("LOOSE_UNLOCK", static_cast<HiFlags>(HiFlags::LOOSE_READ_UNLOCK + HiFlags::LOOSE_WRITE_UNLOCK));
 
     py::register_exception<HiErr>(m, "HiLokError", PyExc_TimeoutError);
 

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -10,7 +10,7 @@ PYBIND11_MODULE(hilok, m)
     py::class_<HiLok, std::shared_ptr<HiLok>>(m, "HiLok")
         .def(py::init<>())
         .def(py::init<char>(), py::arg("sep") = '/')
-        .def(py::init<char, bool>(), py::arg("sep") = '/', py::arg("recursive") = true)
+        .def(py::init<char, bool>(), py::arg("sep") = '/', py::arg("flags") = HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE)
         .def("write", [](std::shared_ptr<HiLok> lok, std::string_view path, std::optional<bool> block, std::optional<double> timeout) {
                 py::gil_scoped_release _gil_rel;
                 if (!block.has_value())
@@ -42,6 +42,14 @@ PYBIND11_MODULE(hilok, m)
         .def("__enter__", [](std::shared_ptr<HiHandle> hh) {return hh;})
         .def("__exit__", [](std::shared_ptr<HiHandle> hh, const py::object &, const py::object &, const py::object &) { hh->release(); })
         ;
+
+    py::enum_<HiFlags>(m, "Flags", py::arithmetic())
+        .value("HI_RECURSIVE_READ", HiFlags::RECURSIVE_READ)
+        .value("HI_RECURSIVE_WRITE", HiFlags::RECURSIVE_WRITE)
+        .value("HI_LOOSE_READ_UNLOCK", HiFlags::LOOSE_READ_UNLOCK)
+        .value("HI_LOOSE_WRITE_UNLOCK", HiFlags::LOOSE_WRITE_UNLOCK)
+        .value("HI_RECURSIVE_ALL", static_cast<HiFlags>(HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE))
+        .export_values();
 
     py::register_exception<HiErr>(m, "HiLokError", PyExc_TimeoutError);
 

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -10,7 +10,7 @@ PYBIND11_MODULE(hilok, m)
     py::class_<HiLok, std::shared_ptr<HiLok>>(m, "HiLok")
         .def(py::init<>())
         .def(py::init<char>(), py::arg("sep") = '/')
-        .def(py::init<char, bool>(), py::arg("sep") = '/', py::arg("flags") = HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE)
+        .def(py::init<char, int>(), py::arg("sep") = '/', py::arg("flags") = HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE)
         .def("write", [](std::shared_ptr<HiLok> lok, std::string_view path, std::optional<bool> block, std::optional<double> timeout) {
                 py::gil_scoped_release _gil_rel;
                 if (!block.has_value())

--- a/src/recsh.cpp
+++ b/src/recsh.cpp
@@ -107,3 +107,12 @@ void recursive_shared_mutex::unlock_shared()
     }
     m_cond_var.notify_all();
 }
+
+void recursive_shared_mutex::unlock_shared(std::thread::id id)
+{
+    {
+        std::unique_lock<std::mutex> sync_lock(m_mtx);
+        decrement_shared_lock(id);
+    }
+    m_cond_var.notify_all();
+}

--- a/src/recsh.cpp
+++ b/src/recsh.cpp
@@ -70,6 +70,17 @@ void recursive_shared_mutex::unlock()
     m_cond_var.notify_all();
 }
 
+void recursive_shared_mutex::unlock(std::thread::id tid)
+{
+    {
+        std::unique_lock<std::mutex> sync_lock(m_mtx);
+        decrement_exclusive_lock(tid);
+        m_solo_locked = false;
+    }
+    m_cond_var.notify_all();
+}
+
+
 void recursive_shared_mutex::lock_shared()
 {
     std::unique_lock<std::mutex> sync_lock(m_mtx);

--- a/src/recsh.cpp
+++ b/src/recsh.cpp
@@ -62,12 +62,7 @@ bool recursive_shared_mutex::try_solo_lock()
 
 void recursive_shared_mutex::unlock()
 {
-    {
-        std::unique_lock<std::mutex> sync_lock(m_mtx);
-        decrement_exclusive_lock();
-        m_solo_locked = false;
-    }
-    m_cond_var.notify_all();
+    unlock(std::this_thread::get_id());
 }
 
 void recursive_shared_mutex::unlock(std::thread::id tid)
@@ -112,11 +107,7 @@ bool recursive_shared_mutex::try_lock_shared()
 
 void recursive_shared_mutex::unlock_shared()
 {
-    {
-        std::unique_lock<std::mutex> sync_lock(m_mtx);
-        decrement_shared_lock();
-    }
-    m_cond_var.notify_all();
+    unlock_shared(std::this_thread::get_id());
 }
 
 void recursive_shared_mutex::unlock_shared(std::thread::id id)

--- a/src/recsh.hpp
+++ b/src/recsh.hpp
@@ -9,12 +9,13 @@
 #include <map>
 #include "hierr.hpp"
 
+
 struct recursive_shared_mutex
 {
 public:
 
     recursive_shared_mutex() :
-        m_mtx{}, m_exclusive_thread_id{}, m_exclusive_count{ 0 }, m_shared_locks{}, m_solo_locked{0}
+        m_mtx{}, m_exclusive_thread_id{}, m_exclusive_count{ 0 }, m_shared_locks{}, m_solo_locked{0}, m_wr_only(false)
     {}
 
     void lock();
@@ -27,6 +28,7 @@ public:
     bool try_lock_shared();
     bool try_lock_shared_for(const std::chrono::duration<double>& secs);
     void unlock_shared();
+    void unlock_shared(std::thread::id id);
 
     recursive_shared_mutex(const recursive_shared_mutex&) = delete;
     recursive_shared_mutex& operator=(const recursive_shared_mutex&) = delete;
@@ -50,7 +52,7 @@ private:
 
     inline bool can_start_exclusive_lock()
     {
-        return !is_exclusive_locked() && (!is_shared_locked() || is_shared_locked_only_on_this_thread());
+        return !is_exclusive_locked() && (!is_shared_locked() || (!m_wr_only && is_shared_locked_only_on_this_thread()));
     }
 
     inline bool can_start_solo_lock()
@@ -172,6 +174,7 @@ private:
     std::map<std::thread::id, size_t> m_shared_locks;
     std::condition_variable m_cond_var;
     bool m_solo_locked;
+    bool m_wr_only;
 };
 
 #endif

--- a/src/recsh.hpp
+++ b/src/recsh.hpp
@@ -14,9 +14,10 @@ struct recursive_shared_mutex
 {
 public:
 
-    recursive_shared_mutex() :
-        m_mtx{}, m_exclusive_thread_id{}, m_exclusive_count{ 0 }, m_shared_locks{}, m_solo_locked{0}, m_wr_only(false)
+    recursive_shared_mutex(bool rec_write_only = false) :
+        m_mtx{}, m_exclusive_thread_id{}, m_exclusive_count{ 0 }, m_shared_locks{}, m_solo_locked{0}, m_wr_only(rec_write_only)
     {}
+
 
     void lock();
     bool try_lock();

--- a/src/recsh.hpp
+++ b/src/recsh.hpp
@@ -68,7 +68,7 @@ private:
 
     inline bool can_lock_shared()
     {
-        return !is_exclusive_locked() || is_exclusive_locked_on_this_thread();
+        return !is_exclusive_locked() || (!m_wr_only && is_exclusive_locked_on_this_thread());
     }
 
     inline bool is_shared_locked_only_on_this_thread()

--- a/src/recsh.hpp
+++ b/src/recsh.hpp
@@ -24,6 +24,7 @@ public:
     bool try_solo_lock();
     bool try_lock_for( const std::chrono::duration<double>& secs);
     void unlock();
+    void unlock(std::thread::id id);
 
     void lock_shared();
     bool try_lock_shared();
@@ -110,11 +111,16 @@ private:
 
     inline void decrement_exclusive_lock()
     {
+        decrement_exclusive_lock(std::this_thread::get_id());
+    }
+
+    inline void decrement_exclusive_lock(std::thread::id tid)
+    {
         if (m_exclusive_count == 0)
         {
             throw HiErr("Not exclusively locked, cannot exclusively unlock");
         }
-        if (m_exclusive_thread_id == std::this_thread::get_id())
+        if (m_exclusive_thread_id == tid)
         {
             m_exclusive_count--;
         }
@@ -123,6 +129,7 @@ private:
             throw HiErr("Calling exclusively unlock from the wrong thread");
         }
     }
+
 
     inline void increment_shared_lock()
     {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -230,7 +230,7 @@ TEST_CASE( "rename-on-top", "[basic]" ) {
 
 
 TEST_CASE( "rename-read-deep", "[basic]" ) {
-    auto h = std::make_shared<HiLok>('/', HiFlags::NONE);
+    auto h = std::make_shared<HiLok>('/', HiFlags::STRICT);
     auto l1 = h->read(h, "a/b/c/d/e/f/g");
     h->rename("a/b/c/d/e/f/g", "a/b/c");
     REQUIRE_THROWS_AS(h->write(h, "a/b/c", false), HiErr);
@@ -299,7 +299,7 @@ void hold_lock_until(std::shared_ptr<HiLok> h, std::string p1, std::string p2) {
 
 
 TEST_CASE( "timed-hlock", "[basic]" ) {
-    auto i = GENERATE(HiFlags::RECURSIVE, HiFlags::NONE);
+    auto i = GENERATE(HiFlags::RECURSIVE, HiFlags::STRICT);
     DYNAMIC_SECTION("recursive " << i) {
     auto h = std::make_shared<HiLok>('/', i);
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -229,6 +229,15 @@ TEST_CASE( "rename-on-top", "[basic]" ) {
 }
 
 
+TEST_CASE( "rename-read-deep", "[basic]" ) {
+    auto h = std::make_shared<HiLok>('/', false);
+    auto l1 = h->read(h, "a/b/c/d/e/f/g");
+    h->rename("a/b/c/d/e/f/g", "a/b/c");
+    REQUIRE_THROWS_AS(h->write(h, "a/b/c", false), HiErr);
+    l1->release();
+    CHECK(h->size() == 0);
+}
+
 
 TEST_CASE( "rlock-simple", "[basic]" ) {
     HiMutex h(true);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -213,6 +213,23 @@ TEST_CASE( "rename-lock", "[basic]" ) {
 }
 
 
+TEST_CASE( "rename-on-top", "[basic]" ) {
+    auto h = std::make_shared<HiLok>('/', false);
+    auto l1 = h->write(h, "a/b/c/d");
+    auto l2 = h->write(h, "a/b/c");
+    h->rename("a/b/c/d", "a/b/c", false);
+   
+    // a/b/c write locked
+    REQUIRE_THROWS_AS(h->read(h, "a/b/c", false), HiErr);
+
+    l1->release();
+    l2->release();
+
+    CHECK(h->size() == 0);
+}
+
+
+
 TEST_CASE( "rlock-simple", "[basic]" ) {
     HiMutex h(true);
     h.lock();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -249,7 +249,7 @@ TEST_CASE( "rename-read-deep", "[basic]" ) {
     auto h = std::make_shared<HiLok>('/', i);
     auto l1 = h->read(h, "a/b/c/d/e/f/g");
     h->rename("a/b/c/d/e/f/g", "a/b/c");
-    REQUIRE_THROWS_AS(h->write(h, "a/b/c", false), HiErr);
+    REQUIRE(thread_check_read_locked(h, "a/b/c"));
     l1->release();
     CHECK(h->size() == 0);
     }
@@ -259,11 +259,14 @@ TEST_CASE( "rename-no-overlap", "[basic]" ) {
     auto i = GENERATE(HiFlags::RECURSIVE, HiFlags::STRICT);
     DYNAMIC_SECTION("recursive " << i) {
     auto h = std::make_shared<HiLok>('/', i);
-    auto l1 = h->read(h, "a/b/c");
-    auto l2 = h->read(h, "d/e/f");
-    h->rename("a/b/c", "d/e/f");
+    auto l1 = h->read(h, "a/b");
+    auto l2 = h->read(h, "d/e");
+    h->rename("a/b", "d/e");
+    INFO("1 unl old a/b (renamed to d/e), should unl d/e");
     l1->release();
+    INFO("2 unl old d/e (gone... should unl old stuff)");
     l2->release();
+    INFO("3 done");
     CHECK(h->size() == 0);
     }
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -248,6 +248,16 @@ TEST_CASE( "rlock-simple", "[basic]" ) {
     h.unlock();
 }
 
+TEST_CASE( "rlock-wronly", "[basic]" ) {
+    HiMutex h(HiFlags::RECURSIVE_WRITE);
+    h.lock();
+    h.lock();
+    CHECK(!h.try_lock_shared());
+    CHECK(h.try_lock());
+    h.unlock();
+    h.unlock();
+}
+
 void rlock_worker(int, HiMutex &h, int &ctr) {
     h.lock();
     h.lock();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -244,12 +244,28 @@ TEST_CASE( "loose-write-unlock", "[basic]" ) {
 }
 
 TEST_CASE( "rename-read-deep", "[basic]" ) {
-    auto h = std::make_shared<HiLok>('/', HiFlags::STRICT);
+    auto i = GENERATE(HiFlags::RECURSIVE, HiFlags::STRICT);
+    DYNAMIC_SECTION("recursive " << i) {
+    auto h = std::make_shared<HiLok>('/', i);
     auto l1 = h->read(h, "a/b/c/d/e/f/g");
     h->rename("a/b/c/d/e/f/g", "a/b/c");
     REQUIRE_THROWS_AS(h->write(h, "a/b/c", false), HiErr);
     l1->release();
     CHECK(h->size() == 0);
+    }
+}
+
+TEST_CASE( "rename-no-overlap", "[basic]" ) {
+    auto i = GENERATE(HiFlags::RECURSIVE, HiFlags::STRICT);
+    DYNAMIC_SECTION("recursive " << i) {
+    auto h = std::make_shared<HiLok>('/', i);
+    auto l1 = h->read(h, "a/b/c");
+    auto l2 = h->read(h, "d/e/f");
+    h->rename("a/b/c", "d/e/f");
+    l1->release();
+    l2->release();
+    CHECK(h->size() == 0);
+    }
 }
 
 TEST_CASE( "rlock-simple", "[basic]" ) {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -214,13 +214,13 @@ TEST_CASE( "rename-lock", "[basic]" ) {
 
 
 TEST_CASE( "rename-on-top", "[basic]" ) {
-    auto h = std::make_shared<HiLok>('/', false);
+    auto h = std::make_shared<HiLok>('/', true);
     auto l1 = h->write(h, "a/b/c/d");
     auto l2 = h->write(h, "a/b/c");
     h->rename("a/b/c/d", "a/b/c", false);
    
     // a/b/c write locked
-    REQUIRE_THROWS_AS(h->read(h, "a/b/c", false), HiErr);
+    CHECK(thread_check_write_locked(h, "a/b/c"));
 
     l1->release();
     l2->release();

--- a/tests/test_hilok.py
+++ b/tests/test_hilok.py
@@ -36,6 +36,16 @@ def test_early_rel():
         h.write("/a/b", block=False)
 
 
+def test_nonoverlap():
+    f1 = "a/b"
+    f2 = "c/d"
+
+    h = HiLok(flags=HiLokFlags.RECURSIVE)
+   
+    with h.read(f1), h.read(f2):
+        h.rename(f1, f2)
+    
+
 def test_rename_norec_write():
     h = HiLok(flags=HiLokFlags.STRICT)
     with h.write("/a/b"):

--- a/tests/test_hilok.py
+++ b/tests/test_hilok.py
@@ -36,21 +36,38 @@ def test_early_rel():
         h.write("/a/b", block=False)
 
 
-def test_rename():
+def test_rename_norec_write():
     h = HiLok(recursive=False)
     with h.write("/a/b"):
-        h.rename("/a/b", "x")
+        h.rename("/a/b", "x", block=False)
         with pytest.raises(HiLokError):
             h.write("x", block=False)
         with h.write("/a/b", block=False):
             pass
-        h.rename("x", "c:/long/path/windows/style")
-        h.rename("c:/long/path/windows/style", "c:/long/path/super")
-        with h.write("c:/long/path"):
-            h.rename("c:/long/path/super", "c:/long/path", block=False)
+        h.rename("x", "c:/long/path/windows/style", block=False)
+        h.rename("c:/long/path/windows/style", "c:/long/path/super", block=False)
+        # long path super is a write lock
+        with h.read("c:/long/path", block=False):
+            pass
+        with pytest.raises(HiLokError):
+            h.write("c:/long/path", block=False)
 
     with pytest.raises(HiLokError):
         h.rename("notthere", "whatever")
+
+def test_rename_norec_read():
+    # real scenario from cvfs
+    h = HiLok(recursive=False)
+    l1 = h.read("/a/b/c/d/e/f/g")
+    h.rename("/a/b/c/d/e/f/g", "/a/b/x")
+
+
+def test_rename_rec_read():
+    # real scenario from cvfs
+    h = HiLok(recursive=True)
+    l1 = h.read("/a/b/c/d/e/f/g")
+    h.rename("/a/b/c/d/e/f/g", "/a/b/x")
+
 
 def test_riaa():
     h = HiLok(recursive=False)

--- a/tests/test_hilok.py
+++ b/tests/test_hilok.py
@@ -1,9 +1,9 @@
 import pytest
-from hilok import HiLok, HiLokError
+from hilok import HiLok, HiLokError, HiLokFlags
 
 
 def test_wr_no_lev():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=HiLokFlags.STRICT)
     lk = h.write("/a/b")
     lk.release()
     lk = h.write("/a/b")
@@ -13,7 +13,7 @@ def test_wr_no_lev():
 
 
 def test_with_wr():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=0)
     with h.write("/a/b"):
         with pytest.raises(HiLokError):
             h.write("/a/b", block=False)
@@ -23,21 +23,21 @@ def test_with_wr():
 
 
 def test_write_parent():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=0)
     with h.read("/a/b/c/d/e"):
         with pytest.raises(HiLokError):
             h.write("/a/b", timeout=0.1)
 
 
 def test_early_rel():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=HiLokFlags.STRICT)
     with h.write("/a/b") as l:
         l.release()
         h.write("/a/b", block=False)
 
 
 def test_rename_norec_write():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=HiLokFlags.STRICT)
     with h.write("/a/b"):
         h.rename("/a/b", "x", block=False)
         with pytest.raises(HiLokError):
@@ -57,20 +57,20 @@ def test_rename_norec_write():
 
 def test_rename_norec_read():
     # real scenario from cvfs
-    h = HiLok(recursive=False)
+    h = HiLok(flags=HiLokFlags.STRICT)
     l1 = h.read("/a/b/c/d/e/f/g")
     h.rename("/a/b/c/d/e/f/g", "/a/b/x")
 
 
 def test_rename_rec_read():
     # real scenario from cvfs
-    h = HiLok(recursive=True)
+    h = HiLok()
     l1 = h.read("/a/b/c/d/e/f/g")
     h.rename("/a/b/c/d/e/f/g", "/a/b/x")
 
 
 def test_riaa():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=HiLokFlags.STRICT)
     l = h.write("/a/b")
     del l
     l = h.write("/a/b")
@@ -78,7 +78,7 @@ def test_riaa():
 
 
 def test_none():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=0)
     l = h.write("/a/b")
     with pytest.raises(HiLokError):
         # none is allowed, and is ignored
@@ -90,7 +90,7 @@ def test_none():
 
 
 def test_with_rd():
-    h = HiLok(recursive=False)
+    h = HiLok(flags=0)
     with h.read("/a/b"):
         with h.read("/a/b", block=False):
             pass
@@ -101,7 +101,7 @@ def test_with_rd():
 
 
 def test_other_sep():
-    h = HiLok(":", recursive=False)
+    h = HiLok(":", flags=0)
     with h.read("a:b"):
         with pytest.raises(HiLokError):
             h.write("a", block=False)

--- a/tests/test_hilok.py
+++ b/tests/test_hilok.py
@@ -22,6 +22,13 @@ def test_with_wr():
         pass
 
 
+def test_write_parent():
+    h = HiLok(recursive=False)
+    with h.read("/a/b/c/d/e"):
+        with pytest.raises(HiLokError):
+            h.write("/a/b", timeout=0.1)
+
+
 def test_early_rel():
     h = HiLok(recursive=False)
     with h.write("/a/b") as l:
@@ -37,7 +44,13 @@ def test_rename():
             h.write("x", block=False)
         with h.write("/a/b", block=False):
             pass
+        h.rename("x", "c:/long/path/windows/style")
+        h.rename("c:/long/path/windows/style", "c:/long/path/super")
+        with h.write("c:/long/path"):
+            h.rename("c:/long/path/super", "c:/long/path", block=False)
 
+    with pytest.raises(HiLokError):
+        h.rename("notthere", "whatever")
 
 def test_riaa():
     h = HiLok(recursive=False)


### PR DESCRIPTION
1. rename still isn't thoroughly tested, added some more, including fixes to cleanup logic when paths are deep and renamed on top of existing paths

2. changed the argument "recursive" to "flags".   flags can be RECURSIVE_WRITE (the value if you accidentally pass a bool), or RECURSIVE (read and write) and can be combined with LOOSE_READ_UNLOCK and LOOSE_WRITE_UNLOCK.

3. "loose" unlocks mean that a matching thread id doesn't matter when unlocking... handles can be passed between threads to manage unlocking.   the flags can be used for write locks, read locks, or combined for both