### PR TITLE
Update README.md & Add yet another lock mode

### DIFF
--- a/.github/workflows/deploy-winosx.yml
+++ b/.github/workflows/deploy-winosx.yml
@@ -14,10 +14,14 @@ jobs:
             python: "3.9"
           - os: windows-latest
             python: "3.10"
+          - os: windows-latest
+            python: "3.11"
           - os: macos-10.15
             python: "3.9"
           - os: macos-latest
             python: "3.10"
+          - os: macos-latest
+            python: "3.11"
     name: ${{matrix.info.os}} ${{ matrix.info.python }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
             python: "3.9"
           - os: windows-latest
             python: "3.9"
-          - os: macos-latest
-            python: "3.10"
+          - os: windows-latest
+            python: "3.11"
           - os: macos-10.15
             python: "3.9"
     name: ${{matrix.info.os}} ${{ matrix.info.python }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Locks are, by default, shared, recursive & timed.
 
 First optional argument to the lock manager is the "sep".
 
-Second optional argument is "recursive" (default true).
+Second optional argument is "flags" (default is HiFlags.RECURSIVE, can be also be HiFlags:STRICT).
 
 ```python
 from hilok import HiLok

--- a/README.md
+++ b/README.md
@@ -33,4 +33,9 @@ with h.read("/some/path"):
     pass
 ```
 
-Lock escalation (read/write/release-read) and de-escalation (write/read/release-write) are supported when RECURSIVE is enabled.
+Lock modes:
+
+ - `HiLokFlags.STRICT` : not reentrant, the good mode
+ - `HiLokFlags.RECURSIVE` : fully reentrant, supports escalation (read/write/release-read) and de-escalation (write/read/release-write)
+ - `HiLokFlags.RECURSIVE_WRITE` : only write-locks are reentrant
+ - `HiLokFlags.RECURSIVE_ONEWAY` : can read-lock while holding a write, but not vice-versa

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Locks are, by default, shared, recursive & timed.
 
 First optional argument to the lock manager is the "sep".
 
-Second optional argument is "flags" (default is HiFlags.RECURSIVE, can be also be HiFlags:STRICT).
+Second optional argument is "flags" (default is HiLokFlags.RECURSIVE, can be also be HiLokFlags:STRICT).
 
 ```python
-from hilok import HiLok
+from hilok import HiLok, HiLokError, HiLokFlags
 
 h = HiLok()     # default sep is '/', can pass it in here
 
@@ -18,7 +18,7 @@ rd = h.read("/some/path")
 # nonblocking, this will fail!
 try:
     wr = h.write("/some", block=False)
-except TimeoutError:
+except HiLokError:
     pass
 
 rd.release()
@@ -33,4 +33,4 @@ with h.read("/some/path"):
     pass
 ```
 
-Lock escalation (read/write/release-read) and de-escalation (write/read/release-write) are supported.
+Lock escalation (read/write/release-read) and de-escalation (write/read/release-write) are supported when RECURSIVE is enabled.

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -7,6 +7,16 @@ namespace py = pybind11;
 PYBIND11_MODULE(hilok, m)
 {   
     m.doc() = "Hierarchical lock manager";
+
+    py::enum_<HiFlags>(m, "HiLokFlags", py::arithmetic())
+        .value("STRICT", HiFlags::STRICT)
+        .value("LOOSE_READ_UNLOCK", HiFlags::LOOSE_READ_UNLOCK)
+        .value("LOOSE_WRITE_UNLOCK", HiFlags::LOOSE_WRITE_UNLOCK)
+        .value("RECURSIVE_WRITE", HiFlags::RECURSIVE_WRITE)
+        .value("RECURSIVE_ONEWAY", HiFlags::RECURSIVE_ONEWAY)
+        .value("RECURSIVE", HiFlags::RECURSIVE)
+        .value("LOOSE_UNLOCK", static_cast<HiFlags>(HiFlags::LOOSE_READ_UNLOCK + HiFlags::LOOSE_WRITE_UNLOCK));
+
     py::class_<HiLok, std::shared_ptr<HiLok>>(m, "HiLok")
         .def(py::init<>())
         .def(py::init<char>(), py::arg("sep") = '/')
@@ -42,15 +52,6 @@ PYBIND11_MODULE(hilok, m)
         .def("__enter__", [](std::shared_ptr<HiHandle> hh) {return hh;})
         .def("__exit__", [](std::shared_ptr<HiHandle> hh, const py::object &, const py::object &, const py::object &) { hh->release(); })
         ;
-
-    py::enum_<HiFlags>(m, "HiLokFlags", py::arithmetic())
-        .value("STRICT", HiFlags::STRICT)
-        .value("LOOSE_READ_UNLOCK", HiFlags::LOOSE_READ_UNLOCK)
-        .value("LOOSE_WRITE_UNLOCK", HiFlags::LOOSE_WRITE_UNLOCK)
-        .value("RECURSIVE_WRITE", HiFlags::RECURSIVE_WRITE)
-        .value("RECURSIVE_ONEWAY", HiFlags::RECURSIVE_ONEWAY)
-        .value("RECURSIVE", static_cast<HiFlags>(HiFlags::RECURSIVE))
-        .value("LOOSE_UNLOCK", static_cast<HiFlags>(HiFlags::LOOSE_READ_UNLOCK + HiFlags::LOOSE_WRITE_UNLOCK));
 
     py::register_exception<HiErr>(m, "HiLokError", PyExc_TimeoutError);
 

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -10,7 +10,7 @@ PYBIND11_MODULE(hilok, m)
     py::class_<HiLok, std::shared_ptr<HiLok>>(m, "HiLok")
         .def(py::init<>())
         .def(py::init<char>(), py::arg("sep") = '/')
-        .def(py::init<char, int>(), py::arg("sep") = '/', py::arg("flags") = HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE)
+        .def(py::init<char, int>(), py::arg("sep") = '/', py::arg("flags") = HiFlags::RECURSIVE)
         .def("write", [](std::shared_ptr<HiLok> lok, std::string_view path, std::optional<bool> block, std::optional<double> timeout) {
                 py::gil_scoped_release _gil_rel;
                 if (!block.has_value())
@@ -48,7 +48,8 @@ PYBIND11_MODULE(hilok, m)
         .value("LOOSE_READ_UNLOCK", HiFlags::LOOSE_READ_UNLOCK)
         .value("LOOSE_WRITE_UNLOCK", HiFlags::LOOSE_WRITE_UNLOCK)
         .value("RECURSIVE_WRITE", HiFlags::RECURSIVE_WRITE)
-        .value("RECURSIVE", static_cast<HiFlags>(HiFlags::RECURSIVE_READ + HiFlags::RECURSIVE_WRITE))
+        .value("RECURSIVE_ONEWAY", HiFlags::RECURSIVE_ONEWAY)
+        .value("RECURSIVE", static_cast<HiFlags>(HiFlags::RECURSIVE))
         .value("LOOSE_UNLOCK", static_cast<HiFlags>(HiFlags::LOOSE_READ_UNLOCK + HiFlags::LOOSE_WRITE_UNLOCK));
 
     py::register_exception<HiErr>(m, "HiLokError", PyExc_TimeoutError);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -172,12 +172,12 @@ TEST_CASE( "lock-escalate-deescalate", "[basic]" ) {
     auto l1 = h->write(h, "a");
     REQUIRE( h->find_node("a") );
     std::cout << "read a" << std::endl;
-    auto l2 = h->read(h, "a");
+    auto l2 = h->read(h, "a", false);
     l1->release();
     auto nod = h->find_node("a");
     REQUIRE(nod);
     CHECK(thread_check_read_locked(h, "a"));
-    auto l3 = h->write(h, "a");
+    auto l3 = h->write(h, "a", false);
     l2->release();
     CHECK(thread_check_write_locked(h, "a"));
     l3->release();
@@ -301,6 +301,21 @@ TEST_CASE( "rlock-wronly", "[basic]" ) {
     h.lock();
     CHECK(!h.try_lock_shared());
     CHECK(h.try_lock());
+    h.unlock();
+    h.unlock();
+}
+
+TEST_CASE( "rlock-oneway", "[basic]" ) {
+    HiMutex h(HiFlags::RECURSIVE_ONEWAY);
+    h.lock();
+    h.lock();
+    CHECK(h.try_lock_shared());
+    CHECK(h.try_lock_shared());
+    CHECK(!h.try_lock());
+    h.unlock_shared();
+    h.unlock_shared();
+    CHECK(h.try_lock());
+    h.unlock();
     h.unlock();
     h.unlock();
 }


### PR DESCRIPTION
 - lock modes are no longer additive, instead it's a list using a mask.  
 - readme matches usage
 - new mode is "one way" which has some confusing semantics but does what we needed