### PR TITLE
fix rename in other thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,12 @@ pybuild:
 cbuild:
 	mkdir cbuild
 
-ctest: cbuild
+ctest: cmake
+	cd cbuild; ctest -v --output-on-failure $(MEMCHECK_FLAGS) .
+
+cmake: cbuild
 	cd cbuild; cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTS=On
 	cd cbuild; cmake --build . -j
-	cd cbuild; ctest -v --output-on-failure $(MEMCHECK_FLAGS) .
 
 covtest: cbuild
 	cd cbuild; cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTS=On -DENABLE_COVERAGE=On
@@ -42,5 +44,5 @@ publish:
 	python setup.py bdist bdist_wheel
 	twine upload dist/*
 
-.PHONY: publish venv requirements pytest pybuild ctest
+.PHONY: publish venv requirements pytest pybuild ctest cmake
 .DELETE_ON_ERROR:

--- a/src/hilok.hpp
+++ b/src/hilok.hpp
@@ -63,7 +63,7 @@ public:
     void unsafe_clone_unlock_shared(HiMutex &src) {
         auto num = (src.m_num_r + (src.m_is_ex ? 1 : 0));
         while (num > 0) {
-            unlock_shared();
+            unlock_shared(true);
             --num;
         }
     }
@@ -163,8 +163,12 @@ public:
         return ret;
     }
 
-    void unlock_shared() {
-        mut_op(unlock_shared);
+    void unlock_shared(bool any_thread = 0) {
+        if(is_recursive() && any_thread) {
+            m_r_mut.unlock_any_shared();
+        } else {
+            mut_op(unlock_shared);
+        }
         --m_num_r;
     }
 

--- a/src/recsh.cpp
+++ b/src/recsh.cpp
@@ -118,3 +118,12 @@ void recursive_shared_mutex::unlock_shared(std::thread::id id)
     }
     m_cond_var.notify_all();
 }
+
+void recursive_shared_mutex::unlock_any_shared()
+{
+    {
+        std::unique_lock<std::mutex> sync_lock(m_mtx);
+        decrement_any_shared_lock(std::this_thread::get_id());
+    }
+    m_cond_var.notify_all();
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -562,3 +562,18 @@ TEST_CASE( "rename-threads", "[basic]" ) {
     CHECK(h->size() == 0);
 }
 
+
+void rename_other_lock(std::shared_ptr<HiLok> &h) {
+    h->rename("a/b/c", "a/c");
+}
+
+
+TEST_CASE( "rename-wrong-thread", "[basic]" ) {
+    auto h = std::make_shared<HiLok>('/', HiFlags::RECURSIVE_ONEWAY | HiFlags::LOOSE_READ_UNLOCK);
+    auto ll = h->read(h, "a/b/c");
+    std::thread thread([&h] () { rename_other_lock(h); });
+    thread.join();
+    CHECK(thread_check_read_locked(h, "a/c"));
+    ll->release();
+}
+


### PR DESCRIPTION
when orphaning a leaf:  renaming a/b/c to a/d, for example, the intermediate nodes need their shared locks freed by another thread

this allows orphan leaf renames

only works with recursive mutexes, otherwise renames of this type are undefined

see std::shared_mutex for why